### PR TITLE
docs: clarify setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,24 @@ built on top of ENS, EFP & ECP
    Replace the variables with your own values.
 
 3. Install dependencies:
-   Make sure you have a new version of bun installed
+   - Make sure you're running **Node.js 22** (the project targets `>=22 <23`).
+   - Install [Bun](https://bun.sh) **1.2.5 or newer**:
 
-```sh
-curl -fsSL https://bun.sh/install | bash
-```
+     ```sh
+     curl -fsSL https://bun.sh/install | bash
+     ```
 
-```sh
-bun install
-```
+   - Install project packages:
+
+     ```sh
+     bun install
+     ```
 
 4. Run the dev server:
    ```sh
    bun run dev
    ```
-   Navigate to [http://localhost:3000/home](http://localhost:3000/home)
+   Navigate to [https://localhost:3010/home](https://localhost:3010/home) and accept the self-signed certificate prompt from your browser.
 
 ### Next Steps
 
@@ -53,4 +56,10 @@ Biome is used for formatting and linting. Install it via [Zed/VSCode extensions]
 
 ```sh
 bun run check
+```
+
+For type safety, also run:
+
+```sh
+bunx tsc --noEmit
 ```

--- a/docs/en/features/gasless-transactions.mdx
+++ b/docs/en/features/gasless-transactions.mdx
@@ -22,8 +22,8 @@ You can approve transactions on Paper to be sponsored by Paper. This means you c
 1. Go to [settings](/settings)
 2. Scroll to "Gasless Posting"
 3. Choose a period of time to approve transactions for
-4. Sign an approval trascation (free, only pay gas fees)
+4. Sign an approval transaction (you'll pay gas once for this approval)
 
-After that, paper will cover the gas fees for your posts.
+After that, Paper will cover the gas fees for your posts, and you can revoke the approval whenever you like.
 
 Learn more: [Official ECP Documentation](https://docs.ethcomments.xyz/)


### PR DESCRIPTION
## Summary
- document the required Node 22 runtime and Bun 1.2.5+ when preparing a local environment
- correct the documented dev server URL to https://localhost:3010 and mention the self-signed certificate prompt
- add a reminder to run the TypeScript type check and clarify the gasless transaction approval step copy

## Testing
- bunx tsc --noEmit
- bun run check *(fails: existing lint rules flag many legacy <img> usages and missing button types across src/)*

------
https://chatgpt.com/codex/tasks/task_e_68d25eabe0688325950a8783a9e883fc